### PR TITLE
Allow GoalSeeker to accept seeker type from args

### DIFF
--- a/lib/goal_seeker.rb
+++ b/lib/goal_seeker.rb
@@ -1,15 +1,3 @@
-class GoalSeeker
-  FIXNUM_MAX = (2**(0.size * 8 -2) -1)
-  FIXNUM_MIN = -(2**(0.size * 8 -2))
-
-  def self.seek start:, goal:, step:1, max_cycles:FIXNUM_MAX, function:
-    # seeker = BruteForceSeeker.new start, goal, step, max_cycles, function
-    seeker = BinarySearchSeeker.new start, goal, step, max_cycles, function
-    seeker.calculate
-  end
-
-end
-
 class BruteForceSeeker
   def initialize(start, goal, step, max_cycles, function)
     @start = start
@@ -29,7 +17,7 @@ class BruteForceSeeker
       change_direction_if_needed
       @cycle += 1
     end
-    @param.round(2)
+    @param.round(4)
   end
 
   def reset_calculation
@@ -97,5 +85,19 @@ class BinarySearchSeeker
       @end_value = mid_value
     end
   end
+end
 
+class GoalSeeker
+  FIXNUM_MAX = (2**(0.size * 8 -2) -1)
+  FIXNUM_MIN = -(2**(0.size * 8 -2))
+  SEEKERS = {
+    brute_force: BruteForceSeeker,
+    binary: BinarySearchSeeker
+  }.freeze
+
+  def self.seek start:, goal:, step:1, max_cycles:FIXNUM_MAX, function:, seeker_type: :binary
+    raise ArgumentError, "Unknown seeker type '#{seeker_type}' - only #{SEEKERS.keys} available" unless SEEKERS.key? seeker_type
+    seeker = SEEKERS[seeker_type].new start, goal, step, max_cycles, function
+    seeker.calculate
+  end
 end

--- a/test/test_goal_seeker.rb
+++ b/test/test_goal_seeker.rb
@@ -50,13 +50,17 @@ class GoalSeekTest < Minitest::Test
     f = Proc.new do |interest|
       total = 0
       (1..57).each do |t|
-        total += BigDecimal.new('787.00') / ((1 + interest)**t)
+        total += 787.00 / ((1 + interest)**t)
       end
       total
     end
 
-    assert_in_epsilon 0.0210, (GoalSeeker.seek start: BigDecimal.new('0.0001'),
-      goal: BigDecimal.new('26000.00'), step: BigDecimal.new('0.0000001'),
-      max_cycles: 1000 * 1000 * 100, function: f), 0.0001
+    assert_in_epsilon 0.0210, (GoalSeeker.seek start: 0.0210,
+      goal: 26000.00, step: 0.00001,
+      max_cycles: 100000, function: f, seeker_type: :brute_force), 0.00001
+  end
+
+  def test_raise_exception_for_unknown_seeker_type
+    assert_raises(ArgumentError) {GoalSeeker.seek  :start=>0 , :goal=>0, :function=>lambda { |x| x }, :seeker_type=>:unknown_seeker}
   end
 end

--- a/test/test_goal_seeker.rb
+++ b/test/test_goal_seeker.rb
@@ -55,7 +55,7 @@ class GoalSeekTest < Minitest::Test
       total
     end
 
-    assert_in_epsilon 0.0210, (GoalSeeker.seek start: 0.0210,
+    assert_in_epsilon 0.0210, (GoalSeeker.seek start: 0.01,
       goal: 26000.00, step: 0.00001,
       max_cycles: 100000, function: f, seeker_type: :brute_force), 0.00001
   end

--- a/test/test_goal_seeker.rb
+++ b/test/test_goal_seeker.rb
@@ -45,4 +45,18 @@ class GoalSeekTest < Minitest::Test
     assert_in_epsilon -1152.70, (GoalSeeker.seek  start: 0 , goal: -27.38, step:0.01,
       max_cycles:1000*1000, function: f), 0.01
   end
+
+  def test_compound_interest_rate
+    f = Proc.new do |interest|
+      total = 0
+      (1..57).each do |t|
+        total += BigDecimal.new('787.00') / ((1 + interest)**t)
+      end
+      total
+    end
+
+    assert_in_epsilon 0.0210, (GoalSeeker.seek start: BigDecimal.new('0.0001'),
+      goal: BigDecimal.new('26000.00'), step: BigDecimal.new('0.0000001'),
+      max_cycles: 1000 * 1000 * 100, function: f), 0.0001
+  end
 end


### PR DESCRIPTION
This is necessary since some types of seeking, such as finding a compound interest rate, require `BruteForceSeeker` to be used.